### PR TITLE
add react hooks tslint rule to frontend repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "tslint-config-inmotionnow",
+  "version": "5.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "tslint-react-hooks": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tslint-react-hooks/-/tslint-react-hooks-2.2.1.tgz",
+      "integrity": "sha512-bqIg2uZe+quJMfSOGc4OOZ4awo6TP1ejGDGS6IKg2WIrS0XnWfhUJ99i3B8rUpnZhuD4vRSvyYIbXPUmEqQxxQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-microsoft-contrib": "^6.1.1",
-    "tslint-react": "^4.0.0"
+    "tslint-react": "^4.0.0",
+    "tslint-react-hooks": "^2.2.1"
   },
   "devDependencies": {
     "tsutils": "^3.10.0",

--- a/tslint.js
+++ b/tslint.js
@@ -7,6 +7,7 @@ module.exports = {
     'tslint-eslint-rules',
     'tslint-microsoft-contrib',
     'tslint-config-prettier',
+    'tslint-react-hooks'
   ],
   rulesDirectory: ['rules'],
   rules: {


### PR DESCRIPTION
Verified that this is a very manageable rule to add.

I only have to change one local function in MDS to not use the word 'use' as a prefix, as a 'use' prefix will be considered the sign of a custom hook.