### PR TITLE
update no-this-assignment rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -14,6 +14,12 @@ module.exports = {
     'completed-docs': false,
     'missing-jsdoc': false,
     'no-spread-object-literal-as-props': true,
+    "no-this-assignment": [
+      true,
+      {
+        "allow-destructuring": true
+      }
+    ],
     'ordered-imports': [
       true,
       {


### PR DESCRIPTION
Allow destructuring to access properties on `this`.

We already allow this in `Opus` via a rule override, but we should allow this in other places (i.e. mds) as well. This will hopefully encourage _only_ destructuring `props` and `state,` if anything, at the top of a function. transitioning to functional components will make this irrelevant, but for now the pattern in the example below will hopefully help moving on from the practice of destructuring everything from `props` and `state` at the top of a function, since typing `this.props` was apparently too many key strokes.

after this is in, we can remove the override from opus as this will be the standard.

```
render() {
  const { props, state } = this

  .
  . lots of code
  .



  return (
    <input disabled={props.disabled} value={state.value} />
  )

}

```

instead of
```
render() {
  const { disabled } = this.props
  const { value } = this.state

  .
  . lots of code
  .



  return (
    <input disabled={disabled} value={value} />
  )

}
```
